### PR TITLE
Issue-229 fix play-by-play timestamp parsing

### DIFF
--- a/basketball_reference_web_scraper/html.py
+++ b/basketball_reference_web_scraper/html.py
@@ -852,7 +852,7 @@ class PlayByPlayRow:
         # Or are one of the table headers for each period group (aria-label = Time)
         return not self.is_start_of_period \
                and self.html[1].get('colspan') != '5' \
-               and self.timestamp_cell.get('aria-label') != 'Time'
+               and not self.timestamp_cell.get('aria-label') in ['Time', '']
 
 
 class DailyBoxScoresPage:


### PR DESCRIPTION
It seems that basketball-reference now has an empty string as the 'aria-label' for `<tr class="thead" >` header rows. This change allows these header rows to be skipped as they do not contain any play-by-play data - i.e. `has_play_by_play_data()` should be `False`.